### PR TITLE
Make Helm chart compatible with Helm 2

### DIFF
--- a/charts/oam-core-resources/Chart.yaml
+++ b/charts/oam-core-resources/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v2
+apiVersion: v1
 name: oam-core-resources
 description: A Helm chart for OAM Core Resources Controller
 
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.2
+version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: v0.41
+appVersion: 0.1.0


### PR DESCRIPTION
 Make Helm chart compatible with Helm 2 and drop v from chart tag. Helm 2 throws the following error during packaging for repo submission and installing from repo:
```
Error: apiVersion 'v2' is not valid. The value must be "v1"
```

The versions are converted to SemVer for consistency between the charts in `crossplane-alpha` channel.